### PR TITLE
specify test file not working with windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "babel-preset-env": "^1.4.0",
     "babel-preset-react": "^6.24.1",
     "babel-preset-stage-0": "^6.24.1",
-    "jest": "^20.0.0",
+    "jest": "^22.4.3",
     "regenerator-runtime": "^0.10.5"
   },
   "scripts": {


### PR DESCRIPTION
test file cannot be specified with jest ver 20.0.0 for windows 10.
``npm run test -- src/01*`` will not find the specified test file in windows 10 with jest ver 20.0.0.
Updating the jest version to the latest one solves this issue.